### PR TITLE
Make the Repo Name and Repo Description XSS safe

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -40,10 +40,13 @@ function HubTab() {
         var html = '';
 
         $(repositories).each(function (index, repository) {
+            // Make the name and description XSS safe
+            var repFullName = $('<div>').text(repository.full_name).html();
+            var repFullDesc = $('<div>').text(repository.description).html();
 
             html += '<div class="content-item">' +
-                '<div class="header"><a href="' + repository.html_url + '">' + repository.full_name + '</a></div>' +
-                '<p class="tagline">' + repository.description + '</p>' +
+                '<div class="header"><a href="' + repository.html_url + '">' + repFullName + '</a></div>' +
+                '<p class="tagline">' + repFullDesc + '</p>' +
                 '<div class="footer">' +
                 '<span class="footer-stat">' +
                 '<i class="fa fa-code-fork"></i>' +


### PR DESCRIPTION
In GitHunt
![](https://i.gyazo.com/f6b91ea18787cf6f4fbce8057f5f5a28.png)

The Repo
![](https://i.gyazo.com/8655ad7115dfe078854fa109bd4dba90.png)


The `<div/>` created a new line between 'Like normal' and 'but useful'. Worried that if someone puts `<script>alert('hello')</script>` in their popular repository description that it will constantly popup 'hello', or worse.