### PR TITLE
Fixed overflowing description.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -133,12 +133,16 @@ div.container {
     border-radius: 4px;
     box-shadow: none;
     color: #333;
+    position: relative;
+    overflow: hidden;
 }
 
 .content-item .header {
     font-weight: bold;
     font-size: 17px;
     margin-bottom: 10px;
+    height: 70%;
+    overflow: hidden;
 }
 
 .content-item p.tagline {


### PR DESCRIPTION
Changed .content-item and .content-item .header to fix the bug where longer descriptions would overflow from the container and other stats would be hidden behind the description.

Before
![screen shot 2016-04-30 at 1 07 14 pm](https://cloud.githubusercontent.com/assets/5698706/14934628/7ded1276-0ed4-11e6-8ce3-4c3923fb469b.png)

After
![screen shot 2016-04-30 at 1 06 38 pm](https://cloud.githubusercontent.com/assets/5698706/14934630/85a06b4e-0ed4-11e6-88e8-41ad4330b539.png)