### PR TITLE
Enable support for GitHub Emojis

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -141,7 +141,6 @@ div.container {
     font-weight: bold;
     font-size: 17px;
     margin-bottom: 10px;
-    height: 70%;
     overflow: hidden;
 }
 
@@ -256,4 +255,8 @@ div.footer span.footer-stat .fa {
     margin: 60px 0 20px;
     padding: 20px 10px;
     background: #ccc;
+}
+
+.git_emoji {
+    height: 20px;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -61,7 +61,7 @@ function HubTab() {
             if(item[0] === ':' && item.slice(-1) === ':') {
                 var str = item.slice(1,-1)
                 if(emojis[str] !== undefined) {
-                    return `<img src=${str}/>`;
+                    return `<img src=${emojis[str]}/>`;
                 }
             }
             return item;
@@ -79,13 +79,13 @@ function HubTab() {
         var html = '';
         $(repositories).each(function (index, repository) {
             var repFullName, repFullDesc;
-            // Make the name and description XSS safe
             if(emojis === undefined) {
+                // Make the name and description XSS safe
                 repFullName = $('<div>').text(repository.full_name).html();
                 repFullDesc = $('<div>').text(repository.description).html();
             } else {
-                repFullName = $('<div>').text(generateEmojifiedHTML(repository.full_name,emojis)).html();
-                repFullDesc = $('<div>').text(generateEmojifiedHTML(repository.description,emojis)).html();
+                repFullName = $('<div>').html(generateEmojifiedHTML(repository.full_name,emojis));
+                repFullDesc = $('<div>').html(generateEmojifiedHTML(repository.description,emojis));
             }
            
 
@@ -256,6 +256,9 @@ function HubTab() {
                         finalHtml = generateReposHtml(data.items, filters.dateRange.lower, filters.dateRange.upper,result);
                     }
                     $(mainContainer).append(finalHtml);
+                    trendingRequest = false;
+                    $('.loading-more').addClass('hide');
+                    saveHuntResult();
                 })
             },
             error: function(xhr, status, error) {
@@ -272,12 +275,6 @@ function HubTab() {
                 } else {
                     $('.main-content').replaceWith('Oops! Could you please refresh the page.');
                 }
-            },
-            complete: function () {
-                trendingRequest = false;
-                $('.loading-more').addClass('hide');
-
-                saveHuntResult();
             }
         });
     };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -45,7 +45,7 @@ function HubTab() {
                 return callback(null,data);
             },
             error: function(xhr, status, error) {
-                return callback(JSON.parse(xhr.responseText));
+                return callback("Error");
             }
         });
     }
@@ -61,7 +61,7 @@ function HubTab() {
             if(item[0] === ':' && item.slice(-1) === ':') {
                 var str = item.slice(1,-1)
                 if(emojis[str] !== undefined) {
-                    return `<img src=${emojis[str]}/>`;
+                    return `<img src=${emojis[str]} alt=${item} class='git_emoji'/>`;
                 }
             }
             return item;
@@ -78,17 +78,8 @@ function HubTab() {
     function generateReposHtml(repositories, lowerDate, upperDate, emojis) {
         var html = '';
         $(repositories).each(function (index, repository) {
-            var repFullName, repFullDesc;
-            if(emojis === undefined) {
-                // Make the name and description XSS safe
-                repFullName = $('<div>').text(repository.full_name).html();
-                repFullDesc = $('<div>').text(repository.description).html();
-            } else {
-                repFullName = $('<div>').html(generateEmojifiedHTML(repository.full_name,emojis));
-                repFullDesc = $('<div>').html(generateEmojifiedHTML(repository.description,emojis));
-            }
-           
-
+            var repFullName = generateEmojifiedHTML(repository.full_name,emojis);
+            var repFullDesc = generateEmojifiedHTML(repository.description,emojis);
             html += '<div class="content-item">' +
                 '<div class="header"><a href="' + repository.html_url + '">' + repFullName + '</a></div>' +
                 '<p class="tagline">' + repFullDesc + '</p>' +
@@ -251,7 +242,8 @@ function HubTab() {
                 fetchGitHubEmojis(function(err,result) {
                     var finalHtml;
                     if(err) {
-                        finalHtml = generateReposHtml(data.items, filters.dateRange.lower, filters.dateRange.upper);         
+                         $('.main-content').replaceWith('Oops! Could you please refresh the page.');
+                         return ;         
                     } else {
                         finalHtml = generateReposHtml(data.items, filters.dateRange.lower, filters.dateRange.upper,result);
                     }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,10 +25,26 @@ function HubTab() {
         refreshDuration = '180',
 
         // The time for last hunt
-        huntTImeKey = 'last_hunt_time';
+        huntTImeKey = 'last_hunt_time',
+
+        //github emojis url
+        emojisUrl='https://api.github.com/emojis';
 
     var filterStorage = new HubStorage();
-
+    function getGitHubEmojis() {
+         var emojis = $.ajax({
+            url: emojisUrl,
+            method: 'get',
+            async: false,
+            success: function (data) {
+                return data;
+            },
+            error: function(xhr, status, error) {
+                //Carry on and show regular data
+            }
+        });
+        return emojis;
+    }
     /**
      * Generates the HTML for batch of repositories
      * @param repositories
@@ -36,9 +52,8 @@ function HubTab() {
      * @param upperDate
      * @returns {string}
      */
-    function generateReposHtml(repositories, lowerDate, upperDate) {
+    function generateReposHtml(repositories, lowerDate, upperDate,emojis) {
         var html = '';
-
         $(repositories).each(function (index, repository) {
             // Make the name and description XSS safe
             var repFullName = $('<div>').text(repository.full_name).html();
@@ -202,7 +217,9 @@ function HubTab() {
                 $('.loading-more').removeClass('hide');
             },
             success: function (data) {
-                var finalHtml = generateReposHtml(data.items, filters.dateRange.lower, filters.dateRange.upper);
+                //get Github Emojis
+                var emojis = getGitHubEmojis();
+                var finalHtml = generateReposHtml(data.items, filters.dateRange.lower, filters.dateRange.upper,emojis);
                 $(mainContainer).append(finalHtml);
             },
             error: function(xhr, status, error) {


### PR DESCRIPTION
Hi there,

With this PR, I want to this extension to support GitHub emojis in any github App description and title using JSON provided by GitHub emoji API(does not need credentials).
Before 
> 
![image](https://cloud.githubusercontent.com/assets/10435209/16352471/3ea7465c-3a8c-11e6-885b-12e4f7e479d9.png)

After
> 
![image](https://cloud.githubusercontent.com/assets/10435209/16352454/0b50c1ca-3a8c-11e6-9d9d-6221a2c329b7.png)

Thanks & Regards,
Tarun Garg