### PR TITLE
Github style description if no description provided

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -141,7 +141,6 @@ div.container {
     font-weight: bold;
     font-size: 17px;
     margin-bottom: 10px;
-    height: 70%;
     overflow: hidden;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,6 +44,10 @@ function HubTab() {
             var repFullName = $('<div>').text(repository.full_name).html();
             var repFullDesc = $('<div>').text(repository.description).html();
 
+            if(repFullDesc === '') {
+                repFullDesc = '<i>No description or website provided</i>';
+            }
+            
             html += '<div class="content-item">' +
                 '<div class="header"><a href="' + repository.html_url + '">' + repFullName + '</a></div>' +
                 '<p class="tagline">' + repFullDesc + '</p>' +


### PR DESCRIPTION
Changes 

- Previously if in any repo user has not provided any description then plugin was showing `null` in description for that repo. But with this commit it show github like  _`No description or website provided`_ message if no description is provided for that repo by user.


After:-
![capture](https://cloud.githubusercontent.com/assets/10435209/16463874/64b71e86-3e55-11e6-9d36-775c0e629b19.PNG)


Before:-

![image](https://cloud.githubusercontent.com/assets/10435209/16463867/5c218e78-3e55-11e6-8f35-aaa6e37c9c6b.png)


PS :- I had removed `height:70%` from stylesheet because it was causing style issues and when i checked the released version of githunt there was no `height:70%` for `.header` accessifier.


@kamranahmedse  Please Review ASAP!