### PR TITLE
Text-overflow for description added :whale:

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -145,7 +145,10 @@ div.container {
 }
 
 .content-item p.tagline {
-    font-weight: normal;
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
     font-size: 13px;
     line-height: 20px;
 }


### PR DESCRIPTION
Current when description of the repo becomes too long then text would overflow the div we are trying to pertain desc in. But with this change we are adding some `webkit` specific multi line text-overflow in `.tagline` class so that now it would show `...` when it will overflow.

Before - 
![before](https://cloud.githubusercontent.com/assets/10435209/16542088/8e002b48-40b7-11e6-921a-4259f90601be.PNG)

After - 
![after](https://cloud.githubusercontent.com/assets/10435209/16542089/9673ecd8-40b7-11e6-942a-eb813aca8175.PNG)

Review ASAP @kamranahmedse ! :boom: 

