### PR TITLE
Change from options_page to options_ui

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,9 @@
     "newtab": "githunt.html"
   },
   "homepage_url": "http://kamranahmed.info/",
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html"
+  },
   "browser_action": {
     "default_title": "Githunt",
     "default_icon": "assets/img/icon128.png"


### PR DESCRIPTION
This appears to be the new way to add this to the manifest and also prevents a warning when installing in firefox as per: https://developer.chrome.com/extensions/optionsV2