### PR TITLE
Fix for Project names overflow

### DIFF
--- a/src/components/repository-grid/grid-item/styles.css
+++ b/src/components/repository-grid/grid-item/styles.css
@@ -72,6 +72,7 @@
 
 .grid-item-container .repo-name {
   font-weight: 700;
+  word-wrap: break-all;
 }
 
 .grid-item-container .repo-body p {


### PR DESCRIPTION
 Project names overflow

<img width="1179" alt="screenshot 2018-10-11 at 12 35 35 pm" src="https://user-images.githubusercontent.com/16939018/46786402-5e6cc880-cd52-11e8-84f8-257ba2321282.png">
