### PR TITLE
Fix text overflow issue with ellipsis

### DIFF
--- a/src/components/repository-grid/grid-item/styles.css
+++ b/src/components/repository-grid/grid-item/styles.css
@@ -29,6 +29,7 @@
   font-weight: 600;
   color: #6c7583;
   font-size: 14px;
+  width: 80%;
 }
 
 .grid-item-container .author-details a {
@@ -71,14 +72,24 @@
 }
 
 .grid-item-container .repo-name {
+  display: block;
   font-weight: 700;
-  word-wrap: break-all;
+  word-break: break-word;
+  width: 100%;
+}
+
+.grid-item-container .repo-name,
+.grid-item-container .author-details h5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .grid-item-container .repo-body p {
   font-size: 14px;
   margin-bottom: 0;
   color: #6e7583;
+  word-break: break-word;
 }
 
 .grid-item-container .repo-footer {

--- a/src/components/repository-list/list-item/styles.css
+++ b/src/components/repository-list/list-item/styles.css
@@ -9,6 +9,16 @@
   margin-bottom: 4px;
   font-size: 20px;
   font-weight: 700;
+  word-break: break-word;
+}
+
+@media (min-width: 768px) {
+  .list-item-container .repo-header h3 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 80%;
+  }
 }
 
 .list-item-container .repo-header h3 .text-normal {
@@ -31,6 +41,7 @@
   margin-bottom: 0;
   display: block;
   max-width: 80%;
+  word-break: break-all;
 }
 
 .list-item-container .repo-footer svg {


### PR DESCRIPTION
**Related Issue**

Fixes #28

Since there's an explicit height on the tiles, an ellipsis can be used to clip the overflowing text.

**Before**

<img width="400" alt="screen shot 2019-02-11 at 8 48 10 pm" src="https://user-images.githubusercontent.com/17421347/52612517-ef59ca80-2e3e-11e9-9651-1f08c01b94b4.png">

**After**

<img width="400" alt="screen shot 2019-02-11 at 8 48 03 pm" src="https://user-images.githubusercontent.com/17421347/52612519-f4b71500-2e3e-11e9-8e02-f0f742b755ba.png">

**Before**
<img width="400" alt="screen shot 2019-02-11 at 8 48 45 pm" src="https://user-images.githubusercontent.com/17421347/52612523-fa145f80-2e3e-11e9-910c-3e8074b21d04.png">

**After**

<img width="400" alt="screen shot 2019-02-11 at 8 48 53 pm" src="https://user-images.githubusercontent.com/17421347/52612529-ff71aa00-2e3e-11e9-83ed-154e7589e292.png">
