### PR TITLE
Fixed watchers parameter to subscribers_count

### DIFF
--- a/src/components/repository-grid/grid-item/index.js
+++ b/src/components/repository-grid/grid-item/index.js
@@ -70,7 +70,7 @@ class GridItem extends React.Component {
                rel="noopener noreferrer"
                target="_blank">
               <Watcher/>
-              { this.props.repository.watchers.toLocaleString() }
+              { this.props.repository.subscribers_count.toLocaleString() }
             </a>
           </div>
         </div>

--- a/src/components/repository-list/list-item/index.js
+++ b/src/components/repository-list/list-item/index.js
@@ -54,7 +54,7 @@ class ListItem extends React.Component {
                rel="noopener noreferrer"
                target="_blank">
               <Watcher/>
-              { this.props.repository.watchers.toLocaleString() }
+              { this.props.repository.subscribers_count.toLocaleString() }
             </a>
           </div>
         </div>


### PR DESCRIPTION
As can be seen here: https://developer.github.com/changes/2012-09-05-watcher-api/

GitHub has made changes to their API where `watchers`, `stargazers_count`, `watchers_count` correspond to the number of users that have starred a repository, while `subscribers_count` corresponds to the number of watchers.