### PR TITLE
Fix grid item body overflow

### DIFF
--- a/src/components/repository-grid/grid-item/index.js
+++ b/src/components/repository-grid/grid-item/index.js
@@ -41,7 +41,7 @@ class GridItem extends React.Component {
             </p>
           </div>
           <div className="repo-body">
-            <p>{ (this.props.repository.description && this.props.repository.description.slice(0, 140)) || 'No description given.' }</p>
+            <p title={this.props.repository.description}>{ (this.props.repository.description && this.props.repository.description.slice(0, 140)) || 'No description given.' }</p>
           </div>
           <div className="repo-footer">
             {

--- a/src/components/repository-grid/grid-item/styles.css
+++ b/src/components/repository-grid/grid-item/styles.css
@@ -86,10 +86,16 @@
 }
 
 .grid-item-container .repo-body p {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  max-height: 4.5em;
+  line-height: 1.5em;
   font-size: 14px;
   margin-bottom: 0;
   color: #6e7583;
   word-break: break-word;
+  overflow: hidden;
 }
 
 .grid-item-container .repo-footer {


### PR DESCRIPTION
Grid layout would broken when a repo has a long Chinese description.