### PR TITLE
Add dark mode

### DIFF
--- a/src/components/filters/date-jump-filter/styles.css
+++ b/src/components/filters/date-jump-filter/styles.css
@@ -22,3 +22,29 @@
   box-shadow: none;
   outline: none;
 }
+
+@media (prefers-color-scheme: dark) {
+  .date-jump-type,
+  .date-jump-type:hover,
+  .date-jump-type:active {
+    background: #30353E !important;
+    border-color: #30353E !important;
+    color: #bdc3ce !important;
+  }
+
+  .date-jump-wrap .dropdown-menu {
+    background-color: #30353E;
+    border-color: #30353E;
+    box-shadow: 0 3px 12px rgba(27, 31, 35, 0.6);
+  }
+
+  .date-jump-wrap .dropdown-menu .dropdown-item {
+    color: #bdc3ce;
+  }
+
+  .date-jump-wrap .dropdown-menu .dropdown-item:hover,
+  .date-jump-wrap .dropdown-menu .dropdown-item:focus {
+    background-color: #484f5d;
+    color: white;
+  }
+}

--- a/src/components/filters/language-filter/styles.css
+++ b/src/components/filters/language-filter/styles.css
@@ -107,3 +107,59 @@
   display: block;
   text-align: left;
 }
+
+@media (prefers-color-scheme: dark) {
+  .language-filter {
+    background: #30353E !important;
+    border-color: #30353E !important;
+    color: #bdc3ce;
+  }
+
+  .language-filter:hover,
+  .language-filter:focus,
+  .language-filter:active {
+    color: white !important;
+  }
+
+  .language-select {
+    border-color: #484f5d;
+    box-shadow: 0 3px 12px rgba(27, 31, 35, 0.6);
+    color: #bdc3ce;
+  }
+
+  .select-menu-header, .select-menu-divider {
+    background: #30353E;
+    border-color: #484f5d;
+  }
+
+  .select-menu-header .select-menu-title, .select-menu-divider {
+    color: #bdc3ce;
+  }
+
+  .select-menu-filters {
+    background-color: #24292E;
+  }
+
+  .select-menu-text-filter {
+    border-color: #484f5d;
+  }
+
+  .select-menu-text-filter input,
+  .select-menu-text-filter input:focus {
+    background-color: #30353E;
+    border-color: #484f5d !important;
+  }
+
+  .select-menu-text-filter input:focus {
+    color:white;
+  }
+
+  .select-menu-item {
+    background-color: #30353E;
+    border-color: #484f5d;
+  }
+
+  .select-menu-item:hover, .select-menu-item.active-item {
+    background-color: #484f5d;
+  }
+}

--- a/src/components/filters/view-filter/styles.css
+++ b/src/components/filters/view-filter/styles.css
@@ -26,3 +26,17 @@
 .view-type button:first-child {
   margin-left: 0;
 }
+
+@media (prefers-color-scheme: dark) {
+  .view-type {
+    background: #30353E;
+  }
+
+  .view-type button {
+    color: #bdc3ce;
+  }
+
+  .view-type button.active, .view-type button:hover {
+    color: white;
+  }
+}

--- a/src/components/repository-grid/grid-item/styles.css
+++ b/src/components/repository-grid/grid-item/styles.css
@@ -98,7 +98,6 @@
   bottom: 20px;
   left: 20px;
   right: 25px;
-  background: white;
   padding: 10px;
 }
 
@@ -120,4 +119,25 @@
   top: -2px;
   fill: #6c757d;
   margin-right: 5px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .grid-item-body {
+    background: #30353E;
+    box-shadow: -5px 10px 60px -13px rgba(0, 0, 0, 0.6);
+  }
+
+  .grid-item-container .author-details h5 {
+    color: #bdc3ce;
+  }
+
+  .grid-item-container .repo-header .repo-meta {
+    color: #6c7583 !important;
+  }
+
+  .grid-item-container .repo-header .repo-meta a,
+  .grid-item-container .repo-body p,
+  .grid-item-container .repo-footer a {
+    color: #939baa;
+  }
 }

--- a/src/components/repository-list/list-item/styles.css
+++ b/src/components/repository-list/list-item/styles.css
@@ -86,3 +86,18 @@
   width: 92px;
   border-radius: 92px;
 }
+
+@media (prefers-color-scheme: dark) {
+  .list-item-container {
+    border-color: #484f5d;
+  }
+
+  .list-item-container .repo-meta {
+    color: #6c7583 !important;
+  }
+
+  .list-item-container .repo-meta a,
+  .list-item-container .repo-footer a {
+    color: #939baa;
+  }
+}

--- a/src/components/repository-list/styles.css
+++ b/src/components/repository-list/styles.css
@@ -5,3 +5,10 @@
   border-radius: 8px;
   box-shadow: -5px 10px 60px -13px rgba(0, 0, 0, 0.20);
 }
+
+@media (prefers-color-scheme: dark) {
+  .list-container {
+    background: #30353E;
+    box-shadow: -5px 10px 60px -13px rgba(0, 0, 0, 0.6);
+  }
+}

--- a/src/components/top-nav/styles.css
+++ b/src/components/top-nav/styles.css
@@ -42,3 +42,13 @@
   border-color: #01aced;
 }
 
+@media (prefers-color-scheme: dark) {
+  .top-nav {
+    background: #1B1D23;
+    border-color: #484f5d;
+  }
+
+  .top-nav .logo-text h4 {
+    color: #bdc3ce;
+  }
+}

--- a/src/containers/feed/styles.css
+++ b/src/containers/feed/styles.css
@@ -54,3 +54,11 @@
 .alert-warning {
   background: #ffa;
 }
+
+@media (prefers-color-scheme: dark) {
+  .alert-warning {
+    background: #37455f;
+    border-color: #37455f;
+    color: #bdc3ce;
+  }
+}

--- a/src/global.css
+++ b/src/global.css
@@ -25,3 +25,22 @@ a {
   background: #1157ed;
   border-color: #1157ed;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #24292E;
+    color: #bdc3ce;
+  }
+
+  a {
+    color: #1DADEB;
+  }
+
+  a:hover {
+    color: #2dc0ff;
+  }
+
+  .text-muted {
+    color: #939baa !important;
+  }
+}


### PR DESCRIPTION
Uses this media query:

```css
@media (prefers-color-scheme: dark) { … }
```

to detect if the user prefers a dark color scheme and applies dark styles if so.

A few screenshots:

<img width="1440" alt="list" src="https://user-images.githubusercontent.com/13663338/90855111-ff7d2f00-e37e-11ea-805c-82b79d8c0eed.png">
<img width="1440" alt="grid" src="https://user-images.githubusercontent.com/13663338/90855108-fbe9a800-e37e-11ea-9490-1afb258f1585.png">
<img width="179" alt="filter-date" src="https://user-images.githubusercontent.com/13663338/90855218-53881380-e37f-11ea-98fe-5d94de9afc76.png">
<img width="436" alt="filter-languages" src="https://user-images.githubusercontent.com/13663338/90855178-39e6cc00-e37f-11ea-9dbe-68491a923b56.png">


Closes #33 