### PR TITLE
Include MLIR in language filter

### DIFF
--- a/src/components/filters/language-filter/languages.json
+++ b/src/components/filters/language-filter/languages.json
@@ -668,6 +668,10 @@
     "value": "Mirah"
   },
   {
+    "title": "MLIR",
+    "value": "MLIR"
+  },
+  {
     "title": "Modelica",
     "value": "Modelica"
   },


### PR DESCRIPTION
This is a newish LLVM project https://mlir.llvm.org/ that's used in a lot of ML compilers and tools such as https://github.com/llvm/torch-mlir. Would be neat to include it in the language filter.

@kamranahmedse 